### PR TITLE
Resolve problema de lint durante a action do GitHub

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,6 +16,5 @@
     "plugins": [
         "react"
     ],
-    "rules": {
-    }
+    "rules": {}
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,10 @@
         "browser": true,
         "es2021": true
     },
-    "extends": "plugin:react/recommended",
+    "extends": [
+        "eslint:recommended",
+        "plugin:react/recommended"        
+    ],
     "overrides": [
     ],
     "parserOptions": {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,16 +18,11 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
-
-     
-      - name: Run ESLint
-        run: npx eslint *.js
-        
-
       # ESLint and Prettier must be in `package.json`
       - name: Install Node.js dependencies
         run: npm ci
-
+      - name: Run ESLint
+        run: npx eslint *.js
       - name: Run linters
         uses: wearerequired/lint-action@v2
         with:

--- a/index.js
+++ b/index.js
@@ -1,17 +1,8 @@
 let totalVisits = 0;
- debugger;
-if (window.onload )
- window.onload = function (){ totalVisits++;
-    debugger;
-    document.getElementById("demo").innerHTML = totalVisits;
 
- }
-
- 
- 
-    
-     
-  
-   
-  
-
+if (window.onload) {
+   window.onload = function () { 
+      totalVisits++;
+      document.getElementById("demo").innerHTML = totalVisits;
+   }
+}


### PR DESCRIPTION
A action do GitHub estava ordenada de forma a tentar rodar o `npx eslint *.js` antes de fazer a instalação das dependências.
Isso estava gerando o erro

<img width="791" alt="Screen Shot 2023-03-02 at 15 34 20" src="https://user-images.githubusercontent.com/762639/222520652-1278a0a5-3982-411a-9f81-6cb2dc3ddac4.png">

Alterei a ordem e resolvi problemas de lint, imagino que isso vá resolver a tarefa #1 
Os problemas de lint são relacionados a presença do `debugger`, por exemplo.
Essa regra diz que `debugger` não pode ser commitado https://eslint.org/docs/latest/rules/no-debugger
